### PR TITLE
Also support passing the long name as a feature

### DIFF
--- a/ethtool.c
+++ b/ethtool.c
@@ -2291,7 +2291,7 @@ static int do_sfeatures(struct cmd_context *ctx)
 	/* Generate cmdline_info for legacy flags and kernel-named
 	 * features, and parse our arguments.
 	 */
-	cmdline_features = calloc(ARRAY_SIZE(off_flag_def) + defs->n_features,
+	cmdline_features = calloc((ARRAY_SIZE(off_flag_def) * 2) + defs->n_features,
 				  sizeof(cmdline_features[0]));
 	if (!cmdline_features) {
 		perror("Cannot parse arguments");
@@ -2303,12 +2303,17 @@ static int do_sfeatures(struct cmd_context *ctx)
 				     off_flag_def[i].value,
 				     &off_flags_wanted, &off_flags_mask,
 				     &cmdline_features[i]);
+	for (i = 0; i < ARRAY_SIZE(off_flag_def); i++)
+		flag_to_cmdline_info(off_flag_def[i].long_name,
+				     off_flag_def[i].value,
+				     &off_flags_wanted, &off_flags_mask,
+                     &cmdline_features[ARRAY_SIZE(off_flag_def) + i]);
 	for (i = 0; i < defs->n_features; i++)
 		flag_to_cmdline_info(
 			defs->def[i].name, FEATURE_FIELD_FLAG(i),
 			&FEATURE_WORD(efeatures->features, i, requested),
 			&FEATURE_WORD(efeatures->features, i, valid),
-			&cmdline_features[ARRAY_SIZE(off_flag_def) + i]);
+			&cmdline_features[(ARRAY_SIZE(off_flag_def) * 2) + i]);
 	parse_generic_cmdline(ctx, &any_changed, cmdline_features,
 			      ARRAY_SIZE(off_flag_def) + defs->n_features);
 	free(cmdline_features);


### PR DESCRIPTION
Short names are listed in the man page, but not through -h.
Additionally, features implemented in the kernel do not have a short
name. Therefore handle long names with the -k flag in addition to short
names.